### PR TITLE
Re-add github_organization to cope with the 1:n GH:TF workspace issue…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "tfe_workspace" "default" {
     for_each = local.connect_vcs_repo
 
     content {
-      identifier         = module.github_repository.full_name
+      identifier         = "${var.github_organization}/${var.github_repository}"
       branch             = var.branch
       ingress_submodules = false
       oauth_token_id     = var.oauth_token_id

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "github_admins" {
   description = "A list of Github teams that should have admins access"
 }
 
+variable "github_organization" {
+  type        = string
+  default     = null
+  description = "The Github organization to connect the workspace to"
+}
+
 variable "github_repository" {
   type        = string
   description = "The Github organization to connect the workspace to"


### PR DESCRIPTION
… that threw vcs_repo error when linking workspaces to already created repos

Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>