### PR TITLE
Add "delete_branch_on_merge" feature

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,14 +13,15 @@ module "workspace_account" {
 }
 
 module "github_repository" {
-  source            = "github.com/schubergphilis/terraform-github-mcaf-repository?ref=v0.1.0"
-  create_repository = var.create_repository
-  name              = var.github_repository
-  admins            = var.github_admins
-  branch_protection = var.branch_protection
-  description       = var.repository_description
-  private           = var.repository_private
-  writers           = var.github_writers
+  source                 = "github.com/schubergphilis/terraform-github-mcaf-repository?ref=v0.1.3"
+  create_repository      = var.create_repository
+  name                   = var.github_repository
+  admins                 = var.github_admins
+  branch_protection      = var.branch_protection
+  delete_branch_on_merge = var.delete_branch_on_merge
+  description            = var.repository_description
+  private                = var.repository_private
+  writers                = var.github_writers
 }
 
 resource "tfe_workspace" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "connect_vcs_repo" {
   description = "Whether or not to connect a VCS repo to the workspace"
 }
 
+variable "delete_branch_on_merge" {
+  type        = bool
+  default     = true
+  description = "Whether or not to delete the branch after a pull request is merged"
+}
+
 variable "file_triggers_enabled" {
   type        = bool
   default     = true
@@ -149,8 +155,8 @@ variable "sensitive_terraform_variables" {
 }
 
 variable "slack_notification_triggers" {
-  type        = list(string)
-  default     = [
+  type = list(string)
+  default = [
     "run:created",
     "run:planning",
     "run:needs_attention",


### PR DESCRIPTION
Add the new "delete branch on merge" feature. Some things:

- Changed the "internal" veriable `auto_delete_head_branch` to `delete_branch_on_merge` to make it more clear what it does
- Changed the default to `true` here since this is a good practise to keep the GitHub repositories clean