### PR TITLE
Fix deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,13 +47,13 @@ resource "tfe_workspace" "default" {
 }
 
 resource "tfe_notification_configuration" "default" {
-  count                 = var.slack_notification_url != null ? 1 : 0
-  name                  = tfe_workspace.default.name
-  destination_type      = "slack"
-  enabled               = length(coalesce(var.slack_notification_triggers, [])) > 0
-  triggers              = var.slack_notification_triggers
-  url                   = var.slack_notification_url
-  workspace_external_id = tfe_workspace.default.external_id
+  count            = var.slack_notification_url != null ? 1 : 0
+  name             = tfe_workspace.default.name
+  destination_type = "slack"
+  enabled          = length(coalesce(var.slack_notification_triggers, [])) > 0
+  triggers         = var.slack_notification_triggers
+  url              = var.slack_notification_url
+  workspace_id     = tfe_workspace.default.external_id
 }
 
 resource "tfe_variable" "aws_access_key_id" {

--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
+
+  required_providers {
+    tfe = "~> 0.18.0"
+  }
 }


### PR DESCRIPTION
This PR fixes one of the deprecation warnings introduced in `0.18`: https://github.com/terraform-providers/terraform-provider-tfe/blob/master/CHANGELOG.md#0180-june-03-2020

FYI:
```All deprecated attributes will be removed 3 months after the release of v0.18.0. You will have until September 3, 2020 to migrate to the preferred attributes.```

