### PR TITLE
Fix deprecation message

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,16 +11,16 @@ module "workspace_account" {
 }
 
 module "github_repository" {
-  source                 = "github.com/schubergphilis/terraform-github-mcaf-repository?ref=v0.1.4"
+  source                 = "github.com/schubergphilis/terraform-github-mcaf-repository?ref=v0.1.6"
   create_repository      = var.create_repository
   name                   = var.github_repository
   admins                 = var.github_admins
   branch_protection      = var.branch_protection
   delete_branch_on_merge = var.delete_branch_on_merge
   description            = var.repository_description
-  private                = var.repository_private
   readers                = var.github_readers
   writers                = var.github_writers
+  visibility             = var.repository_visibility
 }
 
 resource "tfe_workspace" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -142,10 +142,10 @@ variable "repository_description" {
   description = "A description for the Github repository"
 }
 
-variable "repository_private" {
+variable "repository_visibility" {
   type        = bool
   default     = true
-  description = "Make the Github repository private"
+  description = "Make the Github repository visibility"
 }
 
 variable "sensitive_env_variables" {


### PR DESCRIPTION
The github_repository resource now uses a `visibility` attribute to let you choose `public`, `private` or `internal`.