### PR TITLE
Add support for GitLab as a VCS

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,6 +35,7 @@ jobs:
         uses: hashicorp/terraform-github-actions@master
         env:
           AWS_DEFAULT_REGION: eu-west-1
+          GITLAB_TOKEN: 1
         with:
           tf_actions_version: latest
           tf_actions_subcommand: validate

--- a/README.md
+++ b/README.md
@@ -18,31 +18,31 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| github\_repository | The Github organization to connect the workspace to | `string` | n/a | yes |
 | name | A name for the Terraform workspace | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
+| repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | n/a | yes |
 | tags | A mapping of tags to assign to resource | `map(string)` | n/a | yes |
 | terraform\_organization | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | auto\_apply | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `false` | no |
 | branch | The Git branch to trigger the TFE workspace for | `string` | `"master"` | no |
-| branch\_protection | The Github branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
 | clear\_text\_env\_variables | An optional map with clear text environment variables | `map(string)` | `{}` | no |
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
-| connect\_vcs\_repo | Whether or not to connect a VCS repo to the workspace | `bool` | `true` | no |
 | create\_backend\_config | Whether to create a backend.tf containing the remote backend config | `bool` | `true` | no |
 | create\_repository | Whether of not to create a new repository | `bool` | `false` | no |
 | delete\_branch\_on\_merge | Whether or not to delete the branch after a pull request is merged | `bool` | `true` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
-| github\_admins | A list of Github teams that should have admins access | `list(string)` | `[]` | no |
-| github\_organization | The Github organization to connect the workspace to | `string` | `null` | no |
-| github\_readers | A list of Github teams that should have read access | `list(string)` | `[]` | no |
-| github\_writers | A list of Github teams that should have write access | `list(string)` | `[]` | no |
+| github\_admins | A list of GitHub teams that should have admins access | `list(string)` | `[]` | no |
+| github\_branch\_protection | The GitHub branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
+| github\_readers | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
+| github\_writers | A list of GitHub teams that should have write access | `list(string)` | `[]` | no |
+| gitlab\_branch\_protection | The GitLab branches to protect from forced pushes and deletion | <pre>map(object({<br>    push_access_level            = string<br>    merge_access_level           = string<br>    code_owner_approval_required = bool<br>  }))</pre> | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
-| repository\_description | A description for the Github repository | `string` | `null` | no |
-| repository\_visibility | Make the Github repository visibility | `string` | `"private"` | no |
+| repository\_description | A description for the GitHub or GitLab repository | `string` | `null` | no |
+| repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | `null` | no |
+| repository\_visibility | Make the GitHub repository visibility | `string` | `"private"` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
 | sensitive\_terraform\_variables | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |
 | slack\_notification\_triggers | The triggers to send to Slack | `list(string)` | <pre>[<br>  "run:created",<br>  "run:planning",<br>  "run:needs_attention",<br>  "run:applying",<br>  "run:completed",<br>  "run:errored"<br>]</pre> | no |
@@ -51,6 +51,7 @@
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | username | The username for a new pipeline user. | `string` | `null` | no |
+| vcs\_provider | The VCS provider to use | `string` | `"github"` | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "branch_protection" {
     })
   }))
   default     = []
-  description = "The Github branches to protect from forced pushes and deletion"
+  description = "The GitHub branches to protect from forced pushes and deletion"
 }
 
 variable "clear_text_env_variables" {
@@ -88,30 +88,30 @@ variable "file_triggers_enabled" {
 variable "github_admins" {
   type        = list(string)
   default     = []
-  description = "A list of Github teams that should have admins access"
+  description = "A list of GitHub teams that should have admins access"
 }
 
 variable "github_organization" {
   type        = string
   default     = null
-  description = "The Github organization to connect the workspace to"
+  description = "The GitHub organization to connect the workspace to"
 }
 
 variable "github_readers" {
   type        = list(string)
   default     = []
-  description = "A list of Github teams that should have read access"
+  description = "A list of GitHub teams that should have read access"
 }
 
 variable "github_repository" {
   type        = string
-  description = "The Github organization to connect the workspace to"
+  description = "The GitHub repository to connect the workspace to"
 }
 
 variable "github_writers" {
   type        = list(string)
   default     = []
-  description = "A list of Github teams that should have write access"
+  description = "A list of GitHub teams that should have write access"
 }
 
 variable "kms_key_id" {
@@ -140,13 +140,13 @@ variable "policy_arns" {
 variable "repository_description" {
   type        = string
   default     = null
-  description = "A description for the Github repository"
+  description = "A description for the GitHub repository"
 }
 
 variable "repository_visibility" {
   type        = string
   default     = "private"
-  description = "Make the Github repository visibility"
+  description = "Make the GitHub repository visibility"
 }
 
 variable "sensitive_env_variables" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,28 +21,6 @@ variable "branch" {
   description = "The Git branch to trigger the TFE workspace for"
 }
 
-variable "branch_protection" {
-  type = list(object({
-    branches          = list(string)
-    enforce_admins    = bool
-    push_restrictions = list(string)
-
-    required_reviews = object({
-      dismiss_stale_reviews           = bool
-      dismissal_restrictions          = list(string)
-      required_approving_review_count = number
-      require_code_owner_reviews      = bool
-    })
-
-    required_checks = object({
-      strict   = bool
-      contexts = list(string)
-    })
-  }))
-  default     = []
-  description = "The GitHub branches to protect from forced pushes and deletion"
-}
-
 variable "clear_text_env_variables" {
   type        = map(string)
   default     = {}
@@ -67,12 +45,6 @@ variable "create_repository" {
   description = "Whether of not to create a new repository"
 }
 
-variable "connect_vcs_repo" {
-  type        = bool
-  default     = true
-  description = "Whether or not to connect a VCS repo to the workspace"
-}
-
 variable "delete_branch_on_merge" {
   type        = bool
   default     = true
@@ -91,10 +63,26 @@ variable "github_admins" {
   description = "A list of GitHub teams that should have admins access"
 }
 
-variable "github_organization" {
-  type        = string
-  default     = null
-  description = "The GitHub organization to connect the workspace to"
+variable "github_branch_protection" {
+  type = list(object({
+    branches          = list(string)
+    enforce_admins    = bool
+    push_restrictions = list(string)
+
+    required_reviews = object({
+      dismiss_stale_reviews           = bool
+      dismissal_restrictions          = list(string)
+      required_approving_review_count = number
+      require_code_owner_reviews      = bool
+    })
+
+    required_checks = object({
+      strict   = bool
+      contexts = list(string)
+    })
+  }))
+  default     = []
+  description = "The GitHub branches to protect from forced pushes and deletion"
 }
 
 variable "github_readers" {
@@ -103,15 +91,20 @@ variable "github_readers" {
   description = "A list of GitHub teams that should have read access"
 }
 
-variable "github_repository" {
-  type        = string
-  description = "The GitHub repository to connect the workspace to"
-}
-
 variable "github_writers" {
   type        = list(string)
   default     = []
   description = "A list of GitHub teams that should have write access"
+}
+
+variable "gitlab_branch_protection" {
+  type = map(object({
+    push_access_level            = string
+    merge_access_level           = string
+    code_owner_approval_required = bool
+  }))
+  default     = null
+  description = "The GitLab branches to protect from forced pushes and deletion"
 }
 
 variable "kms_key_id" {
@@ -140,13 +133,29 @@ variable "policy_arns" {
 variable "repository_description" {
   type        = string
   default     = null
-  description = "A description for the GitHub repository"
+  description = "A description for the GitHub or GitLab repository"
+}
+
+variable "repository_name" {
+  type        = string
+  description = "The GitHub or GitLab repository to connect the workspace to"
+}
+
+variable "repository_owner" {
+  type        = string
+  default     = null
+  description = "The GitHub organization or GitLab namespace that owns the repository"
 }
 
 variable "repository_visibility" {
   type        = string
   default     = "private"
   description = "Make the GitHub repository visibility"
+
+  validation {
+    condition     = contains(["internal", "private", "public"], var.repository_visibility)
+    error_message = "The repository_visibility value must be either \"internal\", \"private\" or \"public\"."
+  }
 }
 
 variable "sensitive_env_variables" {
@@ -213,6 +222,17 @@ variable "working_directory" {
   type        = string
   default     = "terraform"
   description = "A relative path that Terraform will execute within"
+}
+
+variable "vcs_provider" {
+  type        = string
+  default     = "github"
+  description = "The VCS provider to use"
+
+  validation {
+    condition     = lower(var.vcs_provider) == "gitlab" || lower(var.vcs_provider) == "github"
+    error_message = "The vcs_provider value must be either \"github\" or \"gitlab\"."
+  }
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -230,7 +230,7 @@ variable "vcs_provider" {
   description = "The VCS provider to use"
 
   validation {
-    condition     = lower(var.vcs_provider) == "gitlab" || lower(var.vcs_provider) == "github"
+    condition     = lower(var.vcs_provider) == "github" || lower(var.vcs_provider) == "gitlab"
     error_message = "The vcs_provider value must be either \"github\" or \"gitlab\"."
   }
 }


### PR DESCRIPTION
This PR adds the ability to use GitLab as a VCS for a TFC workspace. Common variables have had their prefixes changed from from `github_` to `repository_`.