### PR TITLE
Remove VCS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 | Name | Version |
 |------|---------|
-| github | n/a |
 | tfe | n/a |
 
 ## Inputs
@@ -21,30 +20,20 @@
 | name | A name for the Terraform workspace | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
 | repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | n/a | yes |
+| repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | n/a | yes |
 | tags | A mapping of tags to assign to resource | `map(string)` | n/a | yes |
 | terraform\_organization | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
-| agent\_pool\_id | Agent pool ID. Requires "execution\_mode" to be set to agent | `string` | `null` | no |
+| agent\_pool\_id | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
 | auto\_apply | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `false` | no |
-| branch | The Git branch to trigger the TFE workspace for | `string` | `"master"` | no |
+| branch | The git branch to trigger the TFE workspace for | `string` | `"master"` | no |
 | clear\_text\_env\_variables | An optional map with clear text environment variables | `map(string)` | `{}` | no |
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
-| create\_backend\_config | Whether to create a backend.tf containing the remote backend config | `bool` | `true` | no |
-| create\_repository | Whether of not to create a new repository | `bool` | `false` | no |
-| delete\_branch\_on\_merge | Whether or not to delete the branch after a pull request is merged | `bool` | `true` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
-| github\_admins | A list of GitHub teams that should have admins access | `list(string)` | `[]` | no |
-| github\_branch\_protection | The GitHub branches to protect from forced pushes and deletion | <pre>list(object({<br>    branches          = list(string)<br>    enforce_admins    = bool<br>    push_restrictions = list(string)<br><br>    required_reviews = object({<br>      dismiss_stale_reviews           = bool<br>      dismissal_restrictions          = list(string)<br>      required_approving_review_count = number<br>      require_code_owner_reviews      = bool<br>    })<br><br>    required_checks = object({<br>      strict   = bool<br>      contexts = list(string)<br>    })<br>  }))</pre> | `[]` | no |
-| github\_readers | A list of GitHub teams that should have read access | `list(string)` | `[]` | no |
-| github\_writers | A list of GitHub teams that should have write access | `list(string)` | `[]` | no |
-| gitlab\_branch\_protection | The GitLab branches to protect from forced pushes and deletion | <pre>map(object({<br>    push_access_level            = string<br>    merge_access_level           = string<br>    code_owner_approval_required = bool<br>  }))</pre> | `null` | no |
 | kms\_key\_id | The KMS key ID used to encrypt the SSM parameters | `string` | `null` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
-| repository\_description | A description for the GitHub or GitLab repository | `string` | `null` | no |
-| repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | `null` | no |
-| repository\_visibility | Make the GitHub repository visibility | `string` | `"private"` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
 | sensitive\_terraform\_variables | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |
 | slack\_notification\_triggers | The triggers to send to Slack | `list(string)` | <pre>[<br>  "run:created",<br>  "run:planning",<br>  "run:needs_attention",<br>  "run:applying",<br>  "run:completed",<br>  "run:errored"<br>]</pre> | no |
@@ -53,14 +42,12 @@
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | username | The username for a new pipeline user. | `string` | `null` | no |
-| vcs\_provider | The VCS provider to use | `string` | `"github"` | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| repo\_full\_name | The full 'organization/repository' name of the repository |
-| workspace\_id | The Terraform workspace ID |
+| workspace\_id | The Terraform Cloud workspace ID |
 
 <!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -1,50 +1,9 @@
-locals {
-  connect_vcs_repo = var.vcs_provider != null ? { create = true } : {}
-}
-
 module "workspace_account" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.1.7"
   name        = var.username
   policy      = var.policy
   policy_arns = var.policy_arns
   tags        = var.tags
-}
-
-module "github_repository" {
-  count                  = var.create_repository && lower(var.vcs_provider) == "github" ? 1 : 0
-  source                 = "github.com/schubergphilis/terraform-github-mcaf-repository?ref=v0.3.4"
-  admins                 = var.github_admins
-  branch_protection      = var.github_branch_protection
-  delete_branch_on_merge = var.delete_branch_on_merge
-  description            = var.repository_description
-  name                   = var.repository_name
-  readers                = var.github_readers
-  visibility             = var.repository_visibility
-  writers                = var.github_writers
-}
-
-resource "github_repository_file" "default" {
-  count               = var.create_backend_config && lower(var.vcs_provider) == "github" ? 1 : 0
-  file                = "${var.working_directory}/backend.tf"
-  branch              = var.branch
-  overwrite_on_create = true
-  repository          = var.repository_name
-
-  content = templatefile("${path.module}/backend.tf.tpl", {
-    organization = var.terraform_organization
-    workspace    = var.name
-  })
-
-  depends_on = [module.github_repository]
-}
-
-module "gitlab_project" {
-  count             = var.create_repository && lower(var.vcs_provider) == "gitlab" ? 1 : 0
-  source            = "github.com/schubergphilis/terraform-gitlab-mcaf-project.git?ref=v0.1.0"
-  name              = var.repository_name
-  branch_protection = var.gitlab_branch_protection
-  description       = var.repository_description
-  namespace         = var.repository_owner
 }
 
 resource "tfe_workspace" "default" {
@@ -60,21 +19,12 @@ resource "tfe_workspace" "default" {
   queue_all_runs        = true
   working_directory     = var.working_directory
 
-  dynamic "vcs_repo" {
-    for_each = local.connect_vcs_repo
-
-    content {
-      identifier         = format("%s/%s", var.repository_owner, var.repository_name)
-      branch             = var.branch
-      ingress_submodules = false
-      oauth_token_id     = var.oauth_token_id
-    }
+  vcs_repo {
+    identifier         = format("%s/%s", var.repository_owner, var.repository_name)
+    branch             = var.branch
+    ingress_submodules = false
+    oauth_token_id     = var.oauth_token_id
   }
-
-  depends_on = [
-    module.github_repository,
-    module.gitlab_project,
-  ]
 }
 
 resource "tfe_notification_configuration" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,4 @@
-output "repo_full_name" {
-  value       = var.create_repository ? module.github_repository[0].full_name : null
-  description = "The full 'organization/repository' name of the repository"
-}
-
 output "workspace_id" {
   value       = tfe_workspace.default.id
-  description = "The Terraform workspace ID"
+  description = "The Terraform Cloud workspace ID"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 variable "agent_pool_id" {
   type        = string
   default     = null
-  description = "Agent pool ID. Requires \"execution_mode\" to be set to agent"
+  description = "Agent pool ID, requires \"execution_mode\" to be set to agent"
 }
 
 variable "auto_apply" {
@@ -24,7 +24,7 @@ variable "auto_apply" {
 variable "branch" {
   type        = string
   default     = "master"
-  description = "The Git branch to trigger the TFE workspace for"
+  description = "The git branch to trigger the TFE workspace for"
 }
 
 variable "clear_text_env_variables" {
@@ -39,24 +39,6 @@ variable "clear_text_terraform_variables" {
   description = "An optional map with clear text Terraform variables"
 }
 
-variable "create_backend_config" {
-  type        = bool
-  default     = true
-  description = "Whether to create a backend.tf containing the remote backend config"
-}
-
-variable "create_repository" {
-  type        = bool
-  default     = false
-  description = "Whether of not to create a new repository"
-}
-
-variable "delete_branch_on_merge" {
-  type        = bool
-  default     = true
-  description = "Whether or not to delete the branch after a pull request is merged"
-}
-
 variable "execution_mode" {
   type        = string
   default     = "remote"
@@ -67,56 +49,6 @@ variable "file_triggers_enabled" {
   type        = bool
   default     = true
   description = "Whether to filter runs based on the changed files in a VCS push"
-}
-
-variable "github_admins" {
-  type        = list(string)
-  default     = []
-  description = "A list of GitHub teams that should have admins access"
-}
-
-variable "github_branch_protection" {
-  type = list(object({
-    branches          = list(string)
-    enforce_admins    = bool
-    push_restrictions = list(string)
-
-    required_reviews = object({
-      dismiss_stale_reviews           = bool
-      dismissal_restrictions          = list(string)
-      required_approving_review_count = number
-      require_code_owner_reviews      = bool
-    })
-
-    required_checks = object({
-      strict   = bool
-      contexts = list(string)
-    })
-  }))
-  default     = []
-  description = "The GitHub branches to protect from forced pushes and deletion"
-}
-
-variable "github_readers" {
-  type        = list(string)
-  default     = []
-  description = "A list of GitHub teams that should have read access"
-}
-
-variable "github_writers" {
-  type        = list(string)
-  default     = []
-  description = "A list of GitHub teams that should have write access"
-}
-
-variable "gitlab_branch_protection" {
-  type = map(object({
-    push_access_level            = string
-    merge_access_level           = string
-    code_owner_approval_required = bool
-  }))
-  default     = null
-  description = "The GitLab branches to protect from forced pushes and deletion"
 }
 
 variable "kms_key_id" {
@@ -142,12 +74,6 @@ variable "policy_arns" {
   description = "A set of policy ARNs to attach to the pipeline user"
 }
 
-variable "repository_description" {
-  type        = string
-  default     = null
-  description = "A description for the GitHub or GitLab repository"
-}
-
 variable "repository_name" {
   type        = string
   description = "The GitHub or GitLab repository to connect the workspace to"
@@ -155,19 +81,7 @@ variable "repository_name" {
 
 variable "repository_owner" {
   type        = string
-  default     = null
   description = "The GitHub organization or GitLab namespace that owns the repository"
-}
-
-variable "repository_visibility" {
-  type        = string
-  default     = "private"
-  description = "Make the GitHub repository visibility"
-
-  validation {
-    condition     = contains(["internal", "private", "public"], var.repository_visibility)
-    error_message = "The repository_visibility value must be either \"internal\", \"private\" or \"public\"."
-  }
 }
 
 variable "sensitive_env_variables" {
@@ -234,17 +148,6 @@ variable "working_directory" {
   type        = string
   default     = "terraform"
   description = "A relative path that Terraform will execute within"
-}
-
-variable "vcs_provider" {
-  type        = string
-  default     = "github"
-  description = "The VCS provider to use"
-
-  validation {
-    condition     = lower(var.vcs_provider) == "github" || lower(var.vcs_provider) == "gitlab"
-    error_message = "The vcs_provider value must be either \"github\" or \"gitlab\"."
-  }
 }
 
 variable "tags" {


### PR DESCRIPTION
We tried to support multiple VCS providers and due to how some written this does not give the best user experience. We tried to several work arounds but ultimately VCS repos should be managed outside of this module and passed into this module creating an implicit dependency so they're created before the workspace is created (and then attached to)."