### PR TITLE
Reinstate vcs connect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | clear\_text\_env\_variables | An optional map with clear text environment variables | `map(string)` | `{}` | no |
 | clear\_text\_hcl\_variables | An optional map with clear text HCL Terraform variables | `map(string)` | `{}` | no |
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
+| connect\_vcs\_repo | Whether to connect a VCS repo to the workspace | `bool` | `true` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 |------|-------------|------|---------|:--------:|
 | name | A name for the Terraform workspace | `string` | n/a | yes |
 | oauth\_token\_id | The OAuth token ID of the VCS provider | `string` | n/a | yes |
-| repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | n/a | yes |
-| repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | n/a | yes |
 | tags | A mapping of tags to assign to resource | `map(string)` | n/a | yes |
 | terraform\_organization | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | agent\_pool\_id | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
@@ -29,12 +27,13 @@
 | clear\_text\_env\_variables | An optional map with clear text environment variables | `map(string)` | `{}` | no |
 | clear\_text\_hcl\_variables | An optional map with clear text HCL Terraform variables | `map(string)` | `{}` | no |
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
-| connect\_vcs\_repo | Whether to connect a VCS repo to the workspace | `bool` | `true` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
+| repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | `null` | no |
+| repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | `null` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
 | sensitive\_hcl\_variables | An optional map with sensitive HCL Terraform variables | <pre>map(object({<br>    sensitive = string<br>  }))</pre> | `{}` | no |
 | sensitive\_terraform\_variables | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  connect_vcs_repo = (var.repository_owner == null || var.repository_name == null) ? {} : { create = true }
+  connect_vcs_repo = (var.repository_owner != null && var.repository_name != null) ? { create = true } : {}
 }
 
 module "workspace_account" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  connect_vcs_repo = var.connect_vcs_repo ? { create = true } : {}
+  connect_vcs_repo = (var.repository_owner == null || var.repository_name == null) ? {} : { create = true }
 }
 
 module "workspace_account" {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  connect_vcs_repo = var.connect_vcs_repo ? { create = true } : {}
+}
+
 module "workspace_account" {
   source      = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.1.7"
   name        = var.username
@@ -19,11 +23,15 @@ resource "tfe_workspace" "default" {
   queue_all_runs        = true
   working_directory     = var.working_directory
 
-  vcs_repo {
-    identifier         = format("%s/%s", var.repository_owner, var.repository_name)
-    branch             = var.branch
-    ingress_submodules = false
-    oauth_token_id     = var.oauth_token_id
+  dynamic "vcs_repo" {
+    for_each = local.connect_vcs_repo
+
+    content {
+      identifier         = format("%s/%s", var.repository_owner, var.repository_name)
+      branch             = var.branch
+      ingress_submodules = false
+      oauth_token_id     = var.oauth_token_id
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,6 @@ variable "branch" {
   description = "The git branch to trigger the TFE workspace for"
 }
 
-variable "connect_vcs_repo" {
-  type        = bool
-  default     = true
-  description = "Whether to connect a VCS repo to the workspace"
-}
-
 variable "clear_text_env_variables" {
   type        = map(string)
   default     = {}
@@ -82,11 +76,13 @@ variable "policy_arns" {
 
 variable "repository_name" {
   type        = string
+  default     = null
   description = "The GitHub or GitLab repository to connect the workspace to"
 }
 
 variable "repository_owner" {
   type        = string
+  default     = null
   description = "The GitHub organization or GitLab namespace that owns the repository"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "branch" {
   description = "The git branch to trigger the TFE workspace for"
 }
 
+variable "connect_vcs_repo" {
+  type        = bool
+  default     = true
+  description = "Whether to connect a VCS repo to the workspace"
+}
+
 variable "clear_text_env_variables" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
This PR reinstates the option to disable connecting to a VCS. This allows for triggering workspaces in alternative ways.