### PR TITLE
Add global_remote_state configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
+| global\_remote\_state | Allow all workspaces in the organization to read the state of this workspace | `bool` | `true` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
+| remote\_state\_consumer\_ids | A set of workspace IDs set as explicit remote state consumers for the given workspace | `set(string)` | `[]` | no |
 | repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | `null` | no |
 | repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | `null` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@
 | clear\_text\_terraform\_variables | An optional map with clear text Terraform variables | `map(string)` | `{}` | no |
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
-| global\_remote\_state | Allow all workspaces in the organization to read the state of this workspace | `bool` | `true` | no |
+| global\_remote\_state | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
 | policy | The policy to attach to the pipeline user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
-| remote\_state\_consumer\_ids | A set of workspace IDs set as explicit remote state consumers for the given workspace | `set(string)` | `[]` | no |
+| remote\_state\_consumer\_ids | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |
 | repository\_name | The GitHub or GitLab repository to connect the workspace to | `string` | `null` | no |
 | repository\_owner | The GitHub organization or GitLab namespace that owns the repository | `string` | `null` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,17 +11,19 @@ module "workspace_account" {
 }
 
 resource "tfe_workspace" "default" {
-  name                  = var.name
-  organization          = var.terraform_organization
-  agent_pool_id         = var.agent_pool_id
-  auto_apply            = var.auto_apply
-  execution_mode        = var.execution_mode
-  file_triggers_enabled = var.file_triggers_enabled
-  ssh_key_id            = var.ssh_key_id
-  terraform_version     = var.terraform_version
-  trigger_prefixes      = var.trigger_prefixes
-  queue_all_runs        = true
-  working_directory     = var.working_directory
+  name                      = var.name
+  organization              = var.terraform_organization
+  agent_pool_id             = var.agent_pool_id
+  auto_apply                = var.auto_apply
+  execution_mode            = var.execution_mode
+  file_triggers_enabled     = var.file_triggers_enabled
+  global_remote_state       = var.global_remote_state
+  remote_state_consumer_ids = var.remote_state_consumer_ids
+  ssh_key_id                = var.ssh_key_id
+  terraform_version         = var.terraform_version
+  trigger_prefixes          = var.trigger_prefixes
+  queue_all_runs            = true
+  working_directory         = var.working_directory
 
   dynamic "vcs_repo" {
     for_each = local.connect_vcs_repo

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "file_triggers_enabled" {
   description = "Whether to filter runs based on the changed files in a VCS push"
 }
 
+variable "global_remote_state" {
+  type        = bool
+  default     = null
+  description = "Allow all workspaces in the organization to read the state of this workspace"
+}
+
 variable "oauth_token_id" {
   type        = string
   description = "The OAuth token ID of the VCS provider"
@@ -66,6 +72,12 @@ variable "policy" {
   type        = string
   default     = null
   description = "The policy to attach to the pipeline user"
+}
+
+variable "remote_state_consumer_ids" {
+  type        = set(string)
+  default     = null
+  description = "A set of workspace IDs set as explicit remote state consumers for this workspace"
 }
 
 variable "policy_arns" {


### PR DESCRIPTION
Add the `global_remote_state` and `remote_state_consumer_ids` configuration (to allow other Workspaces to read the state).

One thing that is bugging me:

```
Using global_remote_state or remote_state_consumer_ids requires 
using the provider with Terraform Cloud or an instance of 
Terraform Enterprise at least as recent as v202104-1.
```
Source:  https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace

How to handle a scenario like this in a/this module