### PR TITLE
Allow TFC agents to use an IAM role to manage account resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 1.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| random | n/a |
 | tfe | n/a |
 
 ## Inputs
@@ -22,6 +23,8 @@
 | tags | A mapping of tags to assign to resource | `map(string)` | n/a | yes |
 | terraform\_organization | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | agent\_pool\_id | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
+| agent\_role\_arn | IAM role ARN used by Terraform Cloud Agent to assume role in the created account | `string` | `null` | no |
+| auth\_method | Configures how the workspace authenticates with the AWS account (can be iam\_role or iam\_user) | `string` | `"iam_user"` | no |
 | auto\_apply | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `false` | no |
 | branch | The git branch to trigger the TFE workspace for | `string` | `"main"` | no |
 | clear\_text\_env\_variables | An optional map with clear text environment variables | `map(string)` | `{}` | no |
@@ -30,11 +33,12 @@
 | execution\_mode | Which execution mode to use | `string` | `"remote"` | no |
 | file\_triggers\_enabled | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
 | global\_remote\_state | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
-| policy | The policy to attach to the pipeline user | `string` | `null` | no |
+| policy | The policy to attach to the pipeline role or user | `string` | `null` | no |
 | policy\_arns | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
 | region | The default region of the account | `string` | `null` | no |
 | remote\_state\_consumer\_ids | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |
 | repository\_identifier | The repository identifier to connect the workspace to | `string` | `null` | no |
+| role\_name | The IAM role name for a new pipeline user | `string` | `null` | no |
 | sensitive\_env\_variables | An optional map with sensitive environment variables | `map(string)` | `{}` | no |
 | sensitive\_hcl\_variables | An optional map with sensitive HCL Terraform variables | <pre>map(object({<br>    sensitive = string<br>  }))</pre> | `{}` | no |
 | sensitive\_terraform\_variables | An optional map with sensitive Terraform variables | `map(string)` | `{}` | no |
@@ -44,14 +48,14 @@
 | team\_access | An optional map with team IDs and workspace access to assign | <pre>map(object({<br>    access  = string,<br>    team_id = string,<br>  }))</pre> | `{}` | no |
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
-| username | The username for a new pipeline user. | `string` | `null` | no |
+| username | The username for a new pipeline user | `string` | `null` | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | The workspace user ARN |
+| arn | The workspace IAM user ARN |
 | workspace\_id | The Terraform Cloud workspace ID |
 
 <!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,33 @@ locals {
   connect_vcs_repo = var.repository_identifier != null ? { create = true } : {}
 }
 
-module "workspace_account" {
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.1.13"
+module "workspace_iam_user" {
+  count  = var.auth_method == "iam_user" ? 1 : 0
+  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.1.13"
+
   name        = var.username
   policy      = var.policy
   policy_arns = var.policy_arns
   tags        = var.tags
+}
+
+resource "random_uuid" "external_id" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+}
+
+module "workspace_iam_role" {
+  count  = var.auth_method == "iam_role" ? 1 : 0
+  source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.2"
+
+  name        = var.role_name
+  role_policy = var.policy
+  policy_arns = var.policy_arns
+  tags        = var.tags
+
+  assume_policy = templatefile("${path.module}/templates/assume_role_policy.tftpl", {
+    external_id = random_uuid.external_id[0].result,
+    role_arn    = var.agent_role_arn,
+  })
 }
 
 resource "tfe_workspace" "default" {
@@ -57,17 +78,39 @@ resource "tfe_team_access" "default" {
 }
 
 resource "tfe_variable" "aws_access_key_id" {
+  count = var.auth_method == "iam_user" ? 1 : 0
+
   key          = "AWS_ACCESS_KEY_ID"
-  value        = module.workspace_account.access_key_id
+  value        = module.workspace_iam_user[0].access_key_id
   category     = "env"
   workspace_id = tfe_workspace.default.id
 }
 
 resource "tfe_variable" "aws_secret_access_key" {
+  count = var.auth_method == "iam_user" ? 1 : 0
+
   key          = "AWS_SECRET_ACCESS_KEY"
-  value        = module.workspace_account.secret_access_key
+  value        = module.workspace_iam_user[0].secret_access_key
   category     = "env"
   sensitive    = true
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "aws_assume_role" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+
+  key          = "aws_assume_role"
+  value        = module.workspace_iam_role[0].arn
+  category     = "terraform"
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "aws_assume_role_external_id" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+
+  key          = "aws_assume_role_external_id"
+  value        = random_uuid.external_id[0].result
+  category     = "terraform"
   workspace_id = tfe_workspace.default.id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "arn" {
-  value       = module.workspace_account.arn
-  description = "The workspace user ARN"
+  value       = try(module.workspace_iam_user[0].arn, "")
+  description = "The workspace IAM user ARN"
 }
 
 output "workspace_id" {

--- a/refactor.tf
+++ b/refactor.tf
@@ -1,0 +1,14 @@
+moved {
+  from = module.workspace_account
+  to   = module.workspace_iam_user[0]
+}
+
+moved {
+  from = tfe_variable.aws_access_key_id
+  to   = tfe_variable.aws_access_key_id[0]
+}
+
+moved {
+  from = tfe_variable.aws_secret_access_key
+  to   = tfe_variable.aws_secret_access_key[0]
+}

--- a/templates/assume_role_policy.tftpl
+++ b/templates/assume_role_policy.tftpl
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "${role_arn}"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "${external_id}"
+                }
+            }
+        }
+    ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,23 @@ variable "agent_pool_id" {
   description = "Agent pool ID, requires \"execution_mode\" to be set to agent"
 }
 
+variable "agent_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM role ARN used by Terraform Cloud Agent to assume role in the created account"
+}
+
+variable "auth_method" {
+  type        = string
+  default     = "iam_user"
+  description = "Configures how the workspace authenticates with the AWS account (can be iam_role or iam_user)"
+
+  validation {
+    condition     = lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_user"
+    error_message = "The auth_method value must be either \"iam_role\" or \"iam_user\"."
+  }
+}
+
 variable "auto_apply" {
   type        = bool
   default     = false
@@ -71,7 +88,7 @@ variable "oauth_token_id" {
 variable "policy" {
   type        = string
   default     = null
-  description = "The policy to attach to the pipeline user"
+  description = "The policy to attach to the pipeline role or user"
 }
 
 variable "remote_state_consumer_ids" {
@@ -90,6 +107,12 @@ variable "repository_identifier" {
   type        = string
   default     = null
   description = "The repository identifier to connect the workspace to"
+}
+
+variable "role_name" {
+  type        = string
+  default     = null
+  description = "The IAM role name for a new pipeline user"
 }
 
 variable "sensitive_env_variables" {
@@ -166,7 +189,7 @@ variable "trigger_prefixes" {
 variable "username" {
   type        = string
   default     = null
-  description = "The username for a new pipeline user."
+  description = "The username for a new pipeline user"
 }
 
 variable "working_directory" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Currently we create an IAM user per workspace in each account to manage AWS resources. This method creates access keys and secret keys in the managed account and adds overhead of rotating these long lived keys and the risk of someone getting access to the keys.

By instead using a role we no longer need to manage these keys or be at risk of them being compromised, and can restrict the role so that it can only be assumed by the account and role used by the TFC agents. We also create a random external ID per workspace role so that should someone get access to the TFC agent role they cannot easily assume roles in managed accounts.