### PR TITLE
Support custom team access permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
 # terraform-aws-mcaf-workspace
 
+Terraform module to create a Terraform Cloud workspace and either a IAM user or role in an AWS account. The user or role credentials are added to the workspace so that Terraform can create resources in the AWS account.
+
+## Usage
+
+### Team access
+
+This module supports assigning an existing team access to the created workspace.
+
+To do this, pass a map to `var.team_access` using the team name as the key and either `access` or `permissions` to assign a team access to the workspace.
+
+Example using a pre-existing role (see [this link](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/team_access#access) for allowed values):
+
+```hcl
+team_access = {
+  "MyTeamName" = {
+    access = "write"
+  }
+}
+```
+
+Example using a custom role (see [this link](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/team_access#permissions) for a list of keys and their allowed values):
+
+```hcl
+team_access = {
+  "MyTeamName" = {
+    permissions = {
+      run_tasks         = false
+      runs              = "apply"
+      sentinel_mocks    = "read"
+      state_versions    = "read-outputs"
+      variables         = "write"
+      workspace_locking = true
+    }
+  }
+}
+```
+
+The above custom role is similar to the "write" pre-existing role, but blocks access to the workspace state (which is considered sensitive).
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | slack\_notification\_triggers | The triggers to send to Slack | `list(string)` | <pre>[<br>  "run:created",<br>  "run:planning",<br>  "run:needs_attention",<br>  "run:applying",<br>  "run:completed",<br>  "run:errored"<br>]</pre> | no |
 | slack\_notification\_url | The Slack Webhook URL to send notification to | `string` | `null` | no |
 | ssh\_key\_id | The SSH key ID to assign to the workspace | `string` | `null` | no |
-| team\_access | An optional map with team IDs and workspace access to assign | <pre>map(object({<br>    access  = string,<br>    team_id = string,<br>  }))</pre> | `{}` | no |
+| team\_access | Map of team names and either type of fixed access or custom permissions to assign | <pre>map(object({<br>    access = optional(string, null),<br>    permissions = optional(object({<br>      run_tasks         = bool<br>      runs              = string<br>      sentinel_mocks    = string<br>      state_versions    = string<br>      variables         = string<br>      workspace_locking = bool<br>    }), null)<br>  }))</pre> | `{}` | no |
 | terraform\_version | The version of Terraform to use for this workspace | `string` | `"latest"` | no |
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | username | The username for a new pipeline user | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -162,11 +162,23 @@ variable "ssh_key_id" {
 
 variable "team_access" {
   type = map(object({
-    access  = string,
-    team_id = string,
+    access = optional(string, null),
+    permissions = optional(object({
+      run_tasks         = bool
+      runs              = string
+      sentinel_mocks    = string
+      state_versions    = string
+      variables         = string
+      workspace_locking = bool
+    }), null)
   }))
   default     = {}
-  description = "An optional map with team IDs and workspace access to assign"
+  description = "Map of team names and either type of fixed access or custom permissions to assign"
+
+  validation {
+    condition     = alltrue([for o in var.team_access : !(o.access != null && o.permissions != null)])
+    error_message = "Cannot use \"access\" or \"permissions\" keys together when specifying a team's access."
+  }
 }
 
 variable "terraform_version" {


### PR DESCRIPTION
Removes `team_id` from `var.team_access`, as the team names are unique per organisation, and added `permissions` as a way to define a custom access role with fine-grained permissions instead of one of the pre-existing roles.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
