### PR TITLE
Add support for Workspace tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | trigger\_prefixes | List of repository-root-relative paths which should be tracked for changes | `list(string)` | <pre>[<br>  "modules"<br>]</pre> | no |
 | username | The username for a new pipeline user | `string` | `null` | no |
 | working\_directory | A relative path that Terraform will execute within | `string` | `"terraform"` | no |
+| workspace\_tags | A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ resource "tfe_workspace" "default" {
   queue_all_runs            = true
   remote_state_consumer_ids = var.remote_state_consumer_ids
   ssh_key_id                = var.ssh_key_id
+  tag_names                 = var.workspace_tags
   terraform_version         = var.terraform_version
   trigger_prefixes          = var.trigger_prefixes
   working_directory         = var.working_directory

--- a/variables.tf
+++ b/variables.tf
@@ -226,6 +226,11 @@ variable "workspace_tags" {
   type        = list(string)
   default     = null
   description = "A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens"
+
+  validation {
+    condition     = alltrue([for workspace_tag in var.workspace_tags : can(regex("^[-:a-z0-9]$", workspace_tag))])
+    error_message = "One or more tags are not in the correct format (lowercase letters, numbers, colons, or hyphens)"
+  }
 }
 
 variable "working_directory" {

--- a/variables.tf
+++ b/variables.tf
@@ -222,6 +222,12 @@ variable "username" {
   description = "The username for a new pipeline user"
 }
 
+variable "workspace_tags" {
+  type        = list(string)
+  default     = null
+  description = "A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens"
+}
+
 variable "working_directory" {
   type        = string
   default     = "terraform"


### PR DESCRIPTION
This PR adds support for adding tags to workspaces.

https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace#tag_names