### PR TITLE
feat: Add OIDC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 
@@ -94,7 +94,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | <a name="input_agent_pool_id"></a> [agent\_pool\_id](#input\_agent\_pool\_id) | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
 | <a name="input_agent_role_arns"></a> [agent\_role\_arns](#input\_agent\_role\_arns) | IAM role ARNs used by Terraform Cloud Agent to assume role in the created account | `list(string)` | `null` | no |
-| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | Configures how the workspace authenticates with the AWS account (can be iam\_role, iam\_user or iam\_role\_oidc) | `string` | `"iam_user"` | no |
+| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | Configures how the workspace authenticates with the AWS account (can be iam\_user, iam\_role, or iam\_role\_oidc) | `string` | `"iam_user"` | no |
 | <a name="input_auto_apply"></a> [auto\_apply](#input\_auto\_apply) | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `false` | no |
 | <a name="input_branch"></a> [branch](#input\_branch) | The git branch to trigger the TFE workspace for | `string` | `"main"` | no |
 | <a name="input_clear_text_env_variables"></a> [clear\_text\_env\_variables](#input\_clear\_text\_env\_variables) | An optional map with clear text environment variables | `map(string)` | `{}` | no |
@@ -103,8 +103,8 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="input_execution_mode"></a> [execution\_mode](#input\_execution\_mode) | Which execution mode to use | `string` | `"remote"` | no |
 | <a name="input_file_triggers_enabled"></a> [file\_triggers\_enabled](#input\_file\_triggers\_enabled) | Whether to filter runs based on the changed files in a VCS push | `bool` | `true` | no |
 | <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
-| <a name="input_oidc_settings"></a> [oidc\_settings](#input\_oidc\_settings) | OIDC settings to use if auth\_method is set to "iam\_role\_oidc" | <pre>object({<br>    audience     = optional(string, "aws.workload.identity")<br>    provider_arn = string<br>    site_address = optional(string, "app.terraform.io")<br>  })</pre> | `null` | no |
-| <a name="input_path"></a> [path](#input\_path) | Path in which to create the iam\_role or iam\_user | `string` | `null` | no |
+| <a name="input_oidc_settings"></a> [oidc\_settings](#input\_oidc\_settings) | OIDC settings to use if "auth\_method" is set to "iam\_role\_oidc" | <pre>object({<br>    audience     = optional(string, "aws.workload.identity")<br>    provider_arn = string<br>    site_address = optional(string, "app.terraform.io")<br>  })</pre> | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path in which to create the IAM role or user | `string` | `null` | no |
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | ARN of the policy that is used to set the permissions boundary for the IAM role or IAM user | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The policy to attach to the pipeline role or user | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform Enterprise organization to create the workspace in | `string` | n/a | yes |
 | <a name="input_agent_pool_id"></a> [agent\_pool\_id](#input\_agent\_pool\_id) | Agent pool ID, requires "execution\_mode" to be set to agent | `string` | `null` | no |
 | <a name="input_agent_role_arns"></a> [agent\_role\_arns](#input\_agent\_role\_arns) | IAM role ARNs used by Terraform Cloud Agent to assume role in the created account | `list(string)` | `null` | no |
-| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | Configures how the workspace authenticates with the AWS account (can be iam\_role or iam\_user) | `string` | `"iam_user"` | no |
+| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | Configures how the workspace authenticates with the AWS account (can be iam\_role, iam\_user or iam\_role\_oidc) | `string` | `"iam_user"` | no |
 | <a name="input_auto_apply"></a> [auto\_apply](#input\_auto\_apply) | Whether to automatically apply changes when a Terraform plan is successful | `bool` | `false` | no |
 | <a name="input_branch"></a> [branch](#input\_branch) | The git branch to trigger the TFE workspace for | `string` | `"main"` | no |
 | <a name="input_clear_text_env_variables"></a> [clear\_text\_env\_variables](#input\_clear\_text\_env\_variables) | An optional map with clear text environment variables | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -175,7 +175,7 @@ resource "tfe_variable" "tfc_aws_run_role_arn" {
   count = local.enable_oidc ? 1 : 0
 
   key          = "TFC_AWS_RUN_ROLE_ARN"
-  value        = module.workspace_iam_role_oidc.arn
+  value        = module.workspace_iam_role_oidc[0].arn
   category     = "env"
   workspace_id = tfe_workspace.default.id
 }

--- a/main.tf
+++ b/main.tf
@@ -3,65 +3,9 @@ locals {
   enable_oidc      = var.auth_method == "iam_role_oidc" && var.oidc_settings != null
 }
 
-data "tfe_team" "default" {
-  for_each = toset(keys(var.team_access))
-
-  name         = each.value
-  organization = var.terraform_organization
-}
-
-module "workspace_iam_user" {
-  count  = var.auth_method == "iam_user" ? 1 : 0
-  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.4.0"
-
-  name                 = var.username
-  path                 = var.path
-  policy               = var.policy
-  policy_arns          = var.policy_arns
-  permissions_boundary = var.permissions_boundary_arn
-  tags                 = var.tags
-}
-
-resource "random_uuid" "external_id" {
-  count = var.auth_method == "iam_role" ? 1 : 0
-}
-
-module "workspace_iam_role" {
-  count  = var.auth_method == "iam_role" ? 1 : 0
-  source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
-
-  name                 = var.role_name
-  path                 = var.path
-  permissions_boundary = var.permissions_boundary_arn
-  policy_arns          = var.policy_arns
-  role_policy          = var.policy
-  tags                 = var.tags
-
-  assume_policy = templatefile("${path.module}/templates/assume_role_policy.tftpl", {
-    external_id    = random_uuid.external_id[0].result,
-    role_arns_json = jsonencode(var.agent_role_arns)
-  })
-}
-
-module "workspace_iam_role_oidc" {
-  count  = local.enable_oidc ? 1 : 0
-  source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
-
-  name                 = var.role_name
-  path                 = var.path
-  permissions_boundary = var.permissions_boundary_arn
-  policy_arns          = var.policy_arns
-  role_policy          = var.policy
-  tags                 = var.tags
-
-  assume_policy = templatefile("${path.module}/templates/assume_role_policy_oidc.tftpl", {
-    audience       = var.oidc_settings.audience,
-    org_name       = var.terraform_organization,
-    provider_arn   = var.oidc_settings.provider_arn,
-    site_address   = var.oidc_settings.site_address,
-    workspace_name = var.name
-  })
-}
+################################################################################
+# Workspace
+################################################################################
 
 resource "tfe_workspace" "default" {
   name                      = var.name
@@ -101,92 +45,6 @@ resource "tfe_notification_configuration" "default" {
   triggers         = var.slack_notification_triggers
   url              = var.slack_notification_url
   workspace_id     = tfe_workspace.default.id
-}
-
-resource "tfe_team_access" "default" {
-  for_each = var.team_access
-
-  access       = each.value.access
-  team_id      = data.tfe_team.default[each.key].id
-  workspace_id = tfe_workspace.default.id
-
-  dynamic "permissions" {
-    for_each = each.value.permissions != null ? { create = true } : {}
-
-    content {
-      run_tasks         = each.value.permissions["run_tasks"]
-      runs              = each.value.permissions["runs"]
-      sentinel_mocks    = each.value.permissions["sentinel_mocks"]
-      state_versions    = each.value.permissions["state_versions"]
-      variables         = each.value.permissions["variables"]
-      workspace_locking = each.value.permissions["workspace_locking"]
-    }
-  }
-}
-
-resource "tfe_variable" "aws_access_key_id" {
-  count = var.auth_method == "iam_user" ? 1 : 0
-
-  key          = "AWS_ACCESS_KEY_ID"
-  value        = module.workspace_iam_user[0].access_key_id
-  category     = "env"
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "aws_secret_access_key" {
-  count = var.auth_method == "iam_user" ? 1 : 0
-
-  key          = "AWS_SECRET_ACCESS_KEY"
-  value        = module.workspace_iam_user[0].secret_access_key
-  category     = "env"
-  sensitive    = true
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "aws_assume_role" {
-  count = var.auth_method == "iam_role" ? 1 : 0
-
-  key          = "aws_assume_role"
-  value        = module.workspace_iam_role[0].arn
-  category     = "terraform"
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "aws_assume_role_external_id" {
-  count = var.auth_method == "iam_role" ? 1 : 0
-
-  key          = "aws_assume_role_external_id"
-  value        = random_uuid.external_id[0].result
-  category     = "terraform"
-  sensitive    = true
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "tfc_aws_provider_auth" {
-  count = local.enable_oidc ? 1 : 0
-
-  key          = "TFC_AWS_PROVIDER_AUTH"
-  value        = "true"
-  category     = "env"
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "tfc_aws_run_role_arn" {
-  count = local.enable_oidc ? 1 : 0
-
-  key          = "TFC_AWS_RUN_ROLE_ARN"
-  value        = module.workspace_iam_role_oidc[0].arn
-  category     = "env"
-  workspace_id = tfe_workspace.default.id
-}
-
-resource "tfe_variable" "tfc_aws_workload_identity_audience" {
-  count = local.enable_oidc ? 1 : 0
-
-  key          = "TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE"
-  value        = var.oidc_settings.audience
-  category     = "env"
-  workspace_id = tfe_workspace.default.id
 }
 
 resource "tfe_variable" "aws_default_region" {
@@ -252,5 +110,167 @@ resource "tfe_variable" "sensitive_hcl_variables" {
   category     = "terraform"
   hcl          = true
   sensitive    = true
+  workspace_id = tfe_workspace.default.id
+}
+
+################################################################################
+# RBAC
+################################################################################
+
+data "tfe_team" "default" {
+  for_each = toset(keys(var.team_access))
+
+  name         = each.value
+  organization = var.terraform_organization
+}
+
+resource "tfe_team_access" "default" {
+  for_each = var.team_access
+
+  access       = each.value.access
+  team_id      = data.tfe_team.default[each.key].id
+  workspace_id = tfe_workspace.default.id
+
+  dynamic "permissions" {
+    for_each = each.value.permissions != null ? { create = true } : {}
+
+    content {
+      run_tasks         = each.value.permissions["run_tasks"]
+      runs              = each.value.permissions["runs"]
+      sentinel_mocks    = each.value.permissions["sentinel_mocks"]
+      state_versions    = each.value.permissions["state_versions"]
+      variables         = each.value.permissions["variables"]
+      workspace_locking = each.value.permissions["workspace_locking"]
+    }
+  }
+}
+
+################################################################################
+# Auth - IAM User
+################################################################################
+
+module "workspace_iam_user" {
+  count  = var.auth_method == "iam_user" ? 1 : 0
+  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.4.0"
+
+  name                 = var.username
+  path                 = var.path
+  policy               = var.policy
+  policy_arns          = var.policy_arns
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
+}
+
+resource "tfe_variable" "aws_access_key_id" {
+  count = var.auth_method == "iam_user" ? 1 : 0
+
+  key          = "AWS_ACCESS_KEY_ID"
+  value        = module.workspace_iam_user[0].access_key_id
+  category     = "env"
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "aws_secret_access_key" {
+  count = var.auth_method == "iam_user" ? 1 : 0
+
+  key          = "AWS_SECRET_ACCESS_KEY"
+  value        = module.workspace_iam_user[0].secret_access_key
+  category     = "env"
+  sensitive    = true
+  workspace_id = tfe_workspace.default.id
+}
+
+################################################################################
+# Auth - IAM Role - External ID & Agent
+################################################################################
+
+resource "random_uuid" "external_id" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+}
+
+module "workspace_iam_role" {
+  count  = var.auth_method == "iam_role" ? 1 : 0
+  source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
+
+  name                 = var.role_name
+  path                 = var.path
+  permissions_boundary = var.permissions_boundary_arn
+  policy_arns          = var.policy_arns
+  role_policy          = var.policy
+  tags                 = var.tags
+
+  assume_policy = templatefile("${path.module}/templates/assume_role_policy.tftpl", {
+    external_id    = random_uuid.external_id[0].result,
+    role_arns_json = jsonencode(var.agent_role_arns)
+  })
+}
+
+resource "tfe_variable" "aws_assume_role" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+
+  key          = "aws_assume_role"
+  value        = module.workspace_iam_role[0].arn
+  category     = "terraform"
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "aws_assume_role_external_id" {
+  count = var.auth_method == "iam_role" ? 1 : 0
+
+  key          = "aws_assume_role_external_id"
+  value        = random_uuid.external_id[0].result
+  category     = "terraform"
+  sensitive    = true
+  workspace_id = tfe_workspace.default.id
+}
+
+################################################################################
+# Auth - IAM Role - OIDC
+################################################################################
+
+module "workspace_iam_role_oidc" {
+  count  = local.enable_oidc ? 1 : 0
+  source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
+
+  name                 = var.role_name
+  path                 = var.path
+  permissions_boundary = var.permissions_boundary_arn
+  policy_arns          = var.policy_arns
+  role_policy          = var.policy
+  tags                 = var.tags
+
+  assume_policy = templatefile("${path.module}/templates/assume_role_policy_oidc.tftpl", {
+    audience       = var.oidc_settings.audience,
+    org_name       = var.terraform_organization,
+    provider_arn   = var.oidc_settings.provider_arn,
+    site_address   = var.oidc_settings.site_address,
+    workspace_name = var.name
+  })
+}
+
+resource "tfe_variable" "tfc_aws_provider_auth" {
+  count = local.enable_oidc ? 1 : 0
+
+  key          = "TFC_AWS_PROVIDER_AUTH"
+  value        = "true"
+  category     = "env"
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "tfc_aws_run_role_arn" {
+  count = local.enable_oidc ? 1 : 0
+
+  key          = "TFC_AWS_RUN_ROLE_ARN"
+  value        = module.workspace_iam_role_oidc[0].arn
+  category     = "env"
+  workspace_id = tfe_workspace.default.id
+}
+
+resource "tfe_variable" "tfc_aws_workload_identity_audience" {
+  count = local.enable_oidc ? 1 : 0
+
+  key          = "TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE"
+  value        = var.oidc_settings.audience
+  category     = "env"
   workspace_id = tfe_workspace.default.id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   connect_vcs_repo = var.repository_identifier != null ? { create = true } : {}
+  enable_oidc      = var.auth_method == "iam_role_oidc" && var.oidc_settings != null
 }
 
 data "tfe_team" "default" {
@@ -43,7 +44,7 @@ module "workspace_iam_role" {
 }
 
 module "workspace_iam_role_oidc" {
-  count  = var.auth_method == "iam_role_oidc" ? 1 : 0
+  count  = local.enable_oidc ? 1 : 0
   source = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
 
   name                 = var.role_name
@@ -162,7 +163,7 @@ resource "tfe_variable" "aws_assume_role_external_id" {
 }
 
 resource "tfe_variable" "tfc_aws_provider_auth" {
-  count = var.auth_method == "iam_role_oidc" ? 1 : 0
+  count = local.enable_oidc ? 1 : 0
 
   key          = "TFC_AWS_PROVIDER_AUTH"
   value        = "true"
@@ -171,7 +172,7 @@ resource "tfe_variable" "tfc_aws_provider_auth" {
 }
 
 resource "tfe_variable" "tfc_aws_run_role_arn" {
-  count = var.auth_method == "iam_role_oidc" ? 1 : 0
+  count = local.enable_oidc ? 1 : 0
 
   key          = "TFC_AWS_RUN_ROLE_ARN"
   value        = module.workspace_iam_role_oidc.arn
@@ -180,7 +181,7 @@ resource "tfe_variable" "tfc_aws_run_role_arn" {
 }
 
 resource "tfe_variable" "tfc_aws_workload_identity_audience" {
-  count = var.auth_method == "iam_role_oidc" ? 1 : 0
+  count = local.enable_oidc ? 1 : 0
 
   key          = "TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE"
   value        = var.oidc_settings.audience

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ data "tfe_team" "default" {
 
 module "workspace_iam_user" {
   count  = var.auth_method == "iam_user" ? 1 : 0
-  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.2.0"
+  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.4.0"
 
   name                 = var.username
   path                 = var.path

--- a/templates/assume_role_policy_oidc.tftpl
+++ b/templates/assume_role_policy_oidc.tftpl
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "${provider_arn}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "${site_address}:aud": "${audience}"
+                },
+                "StringLike": {
+                    "${site_address}:sub": "organization:${org_name}:project:*:workspace:${workspace_name}:run_phase:*"
+                }
+            }
+        }
+    ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "oidc_settings" {
     provider_arn = string
     site_address = optional(string, "app.terraform.io")
   })
-  default     = {}
+  default     = null
   description = "OIDC settings to use if auth method is set to \"iam_role_oidc\""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,9 +27,19 @@ variable "auth_method" {
   description = "Configures how the workspace authenticates with the AWS account (can be iam_role or iam_user)"
 
   validation {
-    condition     = lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_user"
-    error_message = "The auth_method value must be either \"iam_role\" or \"iam_user\"."
+    condition     = lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_user" || lower(var.auth_method) == "iam_role_oidc"
+    error_message = "The auth_method value must be either \"iam_role\", \"iam_user\" or \"iam_role_oidc\"."
   }
+}
+
+variable "oidc_settings" {
+  type = object({
+    audience     = optional(string, "aws.workload.identity")
+    provider_arn = string
+    site_address = optional(string, "app.terraform.io")
+  })
+  default     = {}
+  description = "OIDC settings to use if auth method is set to \"iam_role_oidc\""
 }
 
 variable "auto_apply" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "oidc_settings" {
     site_address = optional(string, "app.terraform.io")
   })
   default     = null
-  description = "OIDC settings to use if auth method is set to \"iam_role_oidc\""
+  description = "OIDC settings to use if auth_method is set to \"iam_role_oidc\""
 }
 
 variable "auto_apply" {
@@ -140,7 +140,7 @@ variable "repository_identifier" {
 variable "role_name" {
   type        = string
   default     = null
-  description = "The IAM role name for a new pipeline user"
+  description = "The IAM role name for a new pipeline role"
 }
 
 variable "sensitive_env_variables" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "agent_role_arns" {
 variable "auth_method" {
   type        = string
   default     = "iam_user"
-  description = "Configures how the workspace authenticates with the AWS account (can be iam_role or iam_user)"
+  description = "Configures how the workspace authenticates with the AWS account (can be iam_role, iam_user or iam_role_oidc)"
 
   validation {
     condition     = lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_user" || lower(var.auth_method) == "iam_role_oidc"

--- a/variables.tf
+++ b/variables.tf
@@ -24,22 +24,12 @@ variable "agent_role_arns" {
 variable "auth_method" {
   type        = string
   default     = "iam_user"
-  description = "Configures how the workspace authenticates with the AWS account (can be iam_role, iam_user or iam_role_oidc)"
+  description = "Configures how the workspace authenticates with the AWS account (can be iam_user, iam_role, or iam_role_oidc)"
 
   validation {
-    condition     = lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_user" || lower(var.auth_method) == "iam_role_oidc"
-    error_message = "The auth_method value must be either \"iam_role\", \"iam_user\" or \"iam_role_oidc\"."
+    condition     = lower(var.auth_method) == "iam_user" || lower(var.auth_method) == "iam_role" || lower(var.auth_method) == "iam_role_oidc"
+    error_message = "The auth_method value must be either \"iam_user\", \"iam_role\", or \"iam_role_oidc\"."
   }
-}
-
-variable "oidc_settings" {
-  type = object({
-    audience     = optional(string, "aws.workload.identity")
-    provider_arn = string
-    site_address = optional(string, "app.terraform.io")
-  })
-  default     = null
-  description = "OIDC settings to use if auth_method is set to \"iam_role_oidc\""
 }
 
 variable "auto_apply" {
@@ -95,10 +85,20 @@ variable "oauth_token_id" {
   description = "The OAuth token ID of the VCS provider"
 }
 
+variable "oidc_settings" {
+  type = object({
+    audience     = optional(string, "aws.workload.identity")
+    provider_arn = string
+    site_address = optional(string, "app.terraform.io")
+  })
+  default     = null
+  description = "OIDC settings to use if \"auth_method\" is set to \"iam_role_oidc\""
+}
+
 variable "path" {
   type        = string
   default     = null
-  description = "Path in which to create the iam_role or iam_user"
+  description = "Path in which to create the IAM role or user"
 }
 
 variable "policy" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This PR adds support for TF Cloud OIDC support by:

- Creating an IAM role with a trust policy that trusts the TFE OIDC provider if it passes in matching claims. The trust policy currently ignores the project the workspace is part of and allows for any type of run.
- Creating the required TFE workspace variables that are required by the AWS TF provider to work with OIDC.

The OIDC provider resource itself needs to be passed in and is - within the scope of MCAF - created by the AVM module as a provider per workspace is imo undesirable.