### PR TITLE
enhancement: Refactor away deprecation warning & set minimum tfe version to v0.51.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.37.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.37.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.51.0 |
 
 ## Modules
 
@@ -86,6 +86,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | [tfe_variable.tfc_aws_run_role_arn](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.tfc_aws_workload_identity_audience](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_workspace.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace) | resource |
+| [tfe_workspace_settings.test-settings](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_settings) | resource |
 | [tfe_team.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/team) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | [tfe_variable.tfc_aws_run_role_arn](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.tfc_aws_workload_identity_audience](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_workspace.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace) | resource |
-| [tfe_workspace_settings.test-settings](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_settings) | resource |
+| [tfe_workspace_settings.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_settings) | resource |
 | [tfe_team.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/team) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,7 @@ locals {
 
 resource "tfe_workspace" "default" {
   name                      = var.name
-  agent_pool_id             = var.agent_pool_id
   auto_apply                = var.auto_apply
-  execution_mode            = var.execution_mode
   file_triggers_enabled     = var.file_triggers_enabled
   global_remote_state       = var.global_remote_state
   organization              = var.terraform_organization
@@ -34,6 +32,12 @@ resource "tfe_workspace" "default" {
       oauth_token_id     = var.oauth_token_id
     }
   }
+}
+
+resource "tfe_workspace_settings" "test-settings" {
+  workspace_id   = tfe_workspace.default.id
+  execution_mode = var.execution_mode
+  agent_pool_id  = var.agent_pool_id
 }
 
 resource "tfe_notification_configuration" "default" {

--- a/main.tf
+++ b/main.tf
@@ -34,10 +34,10 @@ resource "tfe_workspace" "default" {
   }
 }
 
-resource "tfe_workspace_settings" "test-settings" {
-  workspace_id   = tfe_workspace.default.id
-  execution_mode = var.execution_mode
+resource "tfe_workspace_settings" "default" {
   agent_pool_id  = var.agent_pool_id
+  execution_mode = var.execution_mode
+  workspace_id   = tfe_workspace.default.id
 }
 
 resource "tfe_notification_configuration" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "execution_mode" {
   type        = string
   default     = "remote"
   description = "Which execution mode to use"
+
+  validation {
+    condition     = var.execution_mode == "agent" || var.execution_mode == "local" || var.execution_mode == "remote"
+    error_message = "The execution_mode value must be either \"agent\", \"local\", or \"remote\"."
+  }
 }
 
 variable "file_triggers_enabled" {

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     tfe = {
       source  = "hashicorp/tfe"
-      version = ">= 0.37.0"
+      version = ">= 0.51.0"
     }
   }
 }


### PR DESCRIPTION
This PR refactors away the deprecation warning about execution mode: `Use resource tfe_workspace_settings to modify the workspace execution settings. This attribute will be removed in a future release of the provider.`

This is moved to it's own resource `tfe_workspace_settings` in the last version: https://github.com/hashicorp/terraform-provider-tfe/blob/main/CHANGELOG.md#v0510