### PR TITLE
fix: add condition to agent_pool_id to allow for unchanged MCAF AVM condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "tfe_workspace" "default" {
 }
 
 resource "tfe_workspace_settings" "default" {
-  agent_pool_id  = var.execution_mode != "remote" ? var.agent_pool_id : null
+  agent_pool_id  = var.execution_mode == "agent" ? var.agent_pool_id : null
   execution_mode = var.execution_mode
   workspace_id   = tfe_workspace.default.id
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "tfe_workspace" "default" {
 }
 
 resource "tfe_workspace_settings" "default" {
-  agent_pool_id  = var.agent_pool_id
+  agent_pool_id  = var.execution_mode == "remote" ? null : var.agent_pool_id
   execution_mode = var.execution_mode
   workspace_id   = tfe_workspace.default.id
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "tfe_workspace" "default" {
 }
 
 resource "tfe_workspace_settings" "default" {
-  agent_pool_id  = var.execution_mode == "remote" ? null : var.agent_pool_id
+  agent_pool_id  = var.execution_mode != "remote" ? var.agent_pool_id : null
   execution_mode = var.execution_mode
   workspace_id   = tfe_workspace.default.id
 }


### PR DESCRIPTION
With the terraform resource change, agent_pool_id should be null when execution_mode is set to remote. This is currently not supported by the MCAF AVM module for additional_tfe_workspaces, a condition here automatically sets the default tfe_workspace agent_pool_id if null is given for the additional workspace.

This change ensures we always set null for this agent_pool_id if remote_execution is set to "remote", which is the only valid entry.