### PR TITLE
feat: Move User module to the TF Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="module_tfe-workspace"></a> [tfe-workspace](#module\_tfe-workspace) | schubergphilis/mcaf-workspace/tfe | ~> 2.0 |
 | <a name="module_workspace_iam_role"></a> [workspace\_iam\_role](#module\_workspace\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
 | <a name="module_workspace_iam_role_oidc"></a> [workspace\_iam\_role\_oidc](#module\_workspace\_iam\_role\_oidc) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
-| <a name="module_workspace_iam_user"></a> [workspace\_iam\_user](#module\_workspace\_iam\_user) | github.com/schubergphilis/terraform-aws-mcaf-user | v0.4.0 |
+| <a name="module_workspace_iam_user"></a> [workspace\_iam\_user](#module\_workspace\_iam\_user) | schubergphilis/mcaf-user/aws | ~> 0.4 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -80,8 +80,10 @@ resource "tfe_team_access" "default" {
 ################################################################################
 
 module "workspace_iam_user" {
-  count  = var.auth_method == "iam_user" ? 1 : 0
-  source = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.4.0"
+  count = var.auth_method == "iam_user" ? 1 : 0
+
+  source  = "schubergphilis/mcaf-user/aws"
+  version = "~> 0.4"
 
   name                 = var.username
   path                 = var.path


### PR DESCRIPTION
This PR migrates the [terraform-aws-mcaf-user](https://github.com/schubergphilis/terraform-aws-mcaf-user) to be loaded from the TF Registry.