### PR TITLE
enhancement: bump tfe-mcaf-workspace to 2.4.x

### DIFF
--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 
 module "tfe-workspace" {
   source  = "schubergphilis/mcaf-workspace/tfe"
-  version = "~> 2.3.0"
+  version = "~> 2.4.0"
 
   name                           = var.name
   agent_pool_id                  = var.execution_mode == "agent" ? var.agent_pool_id : null

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
bumps tfe-mcaf-workspace to 2.4.x

increase required terraform version to >= 1.7.0 to align with the change in the dependency