### PR TITLE
fix!: known after apply issues with tfe project

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | Name | Type |
 |------|------|
 | [tfe_team_access.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/team_access) | resource |
-| [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project) | data source |
 | [tfe_team.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/team) | data source |
 
 ## Inputs
@@ -117,12 +116,12 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Allow all workspaces in the organization to read the state of this workspace | `bool` | `null` | no |
 | <a name="input_notification_configuration"></a> [notification\_configuration](#input\_notification\_configuration) | Notification configuration, using name as key and config as value | <pre>map(object({<br/>    destination_type = string<br/>    enabled          = optional(bool, true)<br/>    url              = string<br/>    triggers = optional(list(string), [<br/>      "run:created",<br/>      "run:planning",<br/>      "run:needs_attention",<br/>      "run:applying",<br/>      "run:completed",<br/>      "run:errored",<br/>    ])<br/>  }))</pre> | `{}` | no |
 | <a name="input_oauth_token_id"></a> [oauth\_token\_id](#input\_oauth\_token\_id) | The OAuth token ID of the VCS provider | `string` | `null` | no |
-| <a name="input_oidc_settings"></a> [oidc\_settings](#input\_oidc\_settings) | OIDC settings to use if "auth\_method" is set to "iam\_role\_oidc" | <pre>object({<br/>    audience = optional(string, "aws.workload.identity")<br/>    # Apply OIDC trust to all workspaces in the project instead of just this workspace.<br/>    # WARNING: Only enable this setting when the project relates to a single AWS Account to avoid unintended access.<br/>    project_scope = optional(bool, false)<br/>    provider_arn  = string<br/>    site_address  = optional(string, "app.terraform.io")<br/>  })</pre> | `null` | no |
+| <a name="input_oidc_settings"></a> [oidc\_settings](#input\_oidc\_settings) | OIDC settings to use if "auth\_method" is set to "iam\_role\_oidc" | <pre>object({<br/>    audience     = optional(string, "aws.workload.identity")<br/>    project_name = optional(string)<br/>    # Apply OIDC trust to all workspaces in the project instead of just this workspace.<br/>    # WARNING: Only enable this setting when the project relates to a single AWS Account to avoid unintended access.<br/>    project_scope = optional(bool, false)<br/>    provider_arn  = string<br/>    site_address  = optional(string, "app.terraform.io")<br/>  })</pre> | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | Path in which to create the IAM role or user | `string` | `null` | no |
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | ARN of the policy that is used to set the permissions boundary for the IAM role or IAM user | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The policy to attach to the pipeline role or user | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of the TFE project where the workspace should be created | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the TFE project where the workspace should be created | `string` | `null` | no |
 | <a name="input_queue_all_runs"></a> [queue\_all\_runs](#input\_queue\_all\_runs) | When set to false no initial run is queued and all runs triggered by a webhook will not be queued, necessary if you need to set variable sets after creation. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The default region of the account | `string` | `null` | no |
 | <a name="input_remote_state_consumer_ids"></a> [remote\_state\_consumer\_ids](#input\_remote\_state\_consumer\_ids) | A set of workspace IDs set as explicit remote state consumers for this workspace | `set(string)` | `null` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v4.0.0
+
+### Variables (v4.0.0)
+
+- The variable `project_name` has been replaced by `project_id`.
+- A new variable `oidc_settings.project_name` has been added to control the OIDC project filter.
+
 ## Upgrading to v3.0.0
 
 ### Variables (v3.0.0)

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,11 @@
 locals {
-  oidc_project_filter   = try(var.oidc_settings.project_scope, false) ? var.project_name : "*"
+  oidc_project_filter   = try(var.oidc_settings.project_scope, false) ? var.oidc_settings.project_name : "*"
   oidc_workspace_filter = !try(var.oidc_settings.project_scope, false) ? var.name : "*"
 }
 
 ################################################################################
 # Workspace
 ################################################################################
-
-data "tfe_project" "default" {
-  count = var.project_name != null ? 1 : 0
-
-  organization = var.terraform_organization
-  name         = var.project_name
-}
 
 module "tfe-workspace" {
   source  = "schubergphilis/mcaf-workspace/tfe"
@@ -38,7 +31,7 @@ module "tfe-workspace" {
   global_remote_state                          = var.global_remote_state
   notification_configuration                   = var.notification_configuration
   oauth_token_id                               = var.repository_identifier != null ? var.oauth_token_id : null
-  project_id                                   = var.project_name != null ? data.tfe_project.default[0].id : null
+  project_id                                   = var.project_id
   queue_all_runs                               = var.queue_all_runs
   remote_state_consumer_ids                    = var.remote_state_consumer_ids
   repository_identifier                        = var.repository_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -160,7 +160,8 @@ variable "oauth_token_id" {
 
 variable "oidc_settings" {
   type = object({
-    audience = optional(string, "aws.workload.identity")
+    audience     = optional(string, "aws.workload.identity")
+    project_name = optional(string)
     # Apply OIDC trust to all workspaces in the project instead of just this workspace.
     # WARNING: Only enable this setting when the project relates to a single AWS Account to avoid unintended access.
     project_scope = optional(bool, false)
@@ -169,6 +170,11 @@ variable "oidc_settings" {
   })
   default     = null
   description = "OIDC settings to use if \"auth_method\" is set to \"iam_role_oidc\""
+
+  validation {
+    condition     = var.oidc_settings == null || !var.oidc_settings.project_scope || var.oidc_settings.project_name != null
+    error_message = "\"project_name\" must be set in \"oidc_settings\" when \"project_scope\" is enabled."
+  }
 }
 
 variable "path" {
@@ -195,10 +201,10 @@ variable "policy_arns" {
   description = "A set of policy ARNs to attach to the pipeline user"
 }
 
-variable "project_name" {
+variable "project_id" {
   type        = string
   default     = null
-  description = "Name of the TFE project where the workspace should be created"
+  description = "ID of the TFE project where the workspace should be created"
 }
 
 variable "queue_all_runs" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

**Fix known-after-apply error on `tfe_project` data source**

**Problem**
The data `"tfe_project" "default"` data source fails during plan when the project doesn't exist yet (e.g. created in the same apply), causing: `Error: Could not find project`

**Changes**
- Remove the `tfe_project` data source entirely
- Add a `project_id` variable to pass the project ID directly (this was also the pre v3.0.0 variable name)
- Move `project_name` into the `oidc_settings` object, where it's actually used (OIDC project filtering)
- Add validation requiring `project_name` when `project_scope` is enabled
