### PR TITLE
feat: Add postfix option for Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The above custom role is similar to the "write" pre-existing role, but blocks ac
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | ARN of the policy that is used to set the permissions boundary for the IAM role or IAM user | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The policy to attach to the pipeline role or user | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
+| <a name="input_postfix"></a> [postfix](#input\_postfix) | Whether to postfix the IAM resources with e.g. `User` and `Role` | `string` | `true` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the TFE project where the workspace should be created | `string` | `null` | no |
 | <a name="input_queue_all_runs"></a> [queue\_all\_runs](#input\_queue\_all\_runs) | When set to false no initial run is queued and all runs triggered by a webhook will not be queued, necessary if you need to set variable sets after creation. | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The default region of the account | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ module "auth" {
   permissions_boundary_arn = var.permissions_boundary_arn
   policy                   = var.policy
   policy_arns              = var.policy_arns
+  postfix                  = var.postfix
   role_name                = var.role_name
   tags                     = var.tags
   terraform_organization   = var.terraform_organization

--- a/modules/auth/README.md
+++ b/modules/auth/README.md
@@ -47,6 +47,7 @@
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | ARN of the policy that is used to set the permissions boundary for the IAM role or IAM user | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | The policy to attach to the pipeline role or user | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | A set of policy ARNs to attach to the pipeline user | `set(string)` | `[]` | no |
+| <a name="input_postfix"></a> [postfix](#input\_postfix) | Whether to postfix the IAM resources with e.g. `User` and `Role` | `string` | `true` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The IAM role name for a new pipeline role | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resource | `map(string)` | `null` | no |
 | <a name="input_terraform_organization"></a> [terraform\_organization](#input\_terraform\_organization) | The Terraform Enterprise organization to create the workspace in | `string` | `null` | no |

--- a/modules/auth/main.tf
+++ b/modules/auth/main.tf
@@ -16,6 +16,7 @@ module "workspace_iam_user" {
   path                 = var.path
   policy               = var.policy
   policy_arns          = var.policy_arns
+  postfix              = var.postfix
   permissions_boundary = var.permissions_boundary_arn
   tags                 = var.tags
 }
@@ -59,6 +60,7 @@ module "workspace_iam_role" {
   path                 = var.path
   permissions_boundary = var.permissions_boundary_arn
   policy_arns          = var.policy_arns
+  postfix              = var.postfix
   role_policy          = var.policy
   tags                 = var.tags
 
@@ -103,6 +105,7 @@ module "workspace_iam_role_oidc" {
   path                 = var.path
   permissions_boundary = var.permissions_boundary_arn
   policy_arns          = var.policy_arns
+  postfix              = var.postfix
   role_policy          = var.policy
   tags                 = var.tags
 

--- a/modules/auth/variables.tf
+++ b/modules/auth/variables.tf
@@ -51,6 +51,12 @@ variable "policy_arns" {
   description = "A set of policy ARNs to attach to the pipeline user"
 }
 
+variable "postfix" {
+  type        = string
+  default     = true
+  description = "Whether to postfix the IAM resources with e.g. `User` and `Role`"
+}
+
 variable "role_name" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -201,6 +201,12 @@ variable "policy_arns" {
   description = "A set of policy ARNs to attach to the pipeline user"
 }
 
+variable "postfix" {
+  type        = string
+  default     = true
+  description = "Whether to postfix the IAM resources with e.g. `User` and `Role`"
+}
+
 variable "project_id" {
   type        = string
   default     = null


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The IAM modules (user/role) have the option to "postfix" the resources with e.g. `User`, `Role` and `Policy`. This PR add this features. Defaults to `true` (the current behaviour).

## :rocket: Motivation

It can be weird/unexpected to specify `MyRole` and end up with `MyRoleRole`. Make this configurable so it can be disabled. Kept it `true` for backwards compatibility

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
